### PR TITLE
chore: merge develop to main for 2.1.0 release

### DIFF
--- a/releases/2.1.0.md
+++ b/releases/2.1.0.md
@@ -1,0 +1,189 @@
+# Axeptio Android SDK - Version 2.1.0 Release Notes
+
+**Release Date:** November 27, 2025
+**Package:** `io.axept.android:android-sdk:2.1.0`
+
+---
+
+## Overview
+
+Version 2.1.0 introduces new configuration options for consent management, improved TCF compliance, and enhanced testing capabilities for widget development.
+
+---
+
+## What's New
+
+### Configurable Consent Expiration
+Control how long user consent decisions are stored with the new `cookiesDurationDays` parameter.
+
+**Use Case:** Set custom expiration periods for consent data based on your privacy requirements.
+
+```kotlin
+Axeptio.initialize(
+    context = this,
+    clientId = "your-client-id",
+    cookiesVersion = "your-version",
+    cookiesDurationDays = 365  // New parameter
+)
+```
+
+### Widget Testing Modes
+Easily test different widget versions during development with new environment selection.
+
+**Available Modes:**
+- `PRODUCTION` - Live production widget (default)
+- `STAGING` - Test staging environment
+- `PR` - Test specific pull request versions
+
+```kotlin
+Axeptio.initialize(
+    context = this,
+    clientId = "your-client-id",
+    cookiesVersion = "your-version",
+    widgetType = WidgetType.STAGING,  // New parameter
+    prId = "123"  // Optional: for PR testing
+)
+```
+
+### Session-Only Consent Support
+Configure consent banners to reappear after each session with storage scope support.
+
+**Use Case:** Ideal for scenarios requiring consent renewal per session rather than persistent storage.
+
+### Enhanced TCF Compliance
+Improved parsing and handling of TCF vendor consent strings for better IAB TCF 2.2 compliance.
+
+---
+
+## Improvements
+
+### Build & Testing
+- Fixed unit test compatibility with release builds
+- All 72 unit tests now pass on both debug and release configurations
+- Improved build configuration following Android library best practices
+
+### Code Quality
+- Removed deprecated Maestro UI testing infrastructure
+- Cleaner build configuration
+- Updated ProGuard consumer rules for better app integration
+
+---
+
+## Dependency Updates
+
+- Added: `com.iabtcf:iabtcf-decoder:2.0.10` for TCF string decoding
+
+---
+
+## Migration Guide
+
+### Updating from 2.0.x
+
+No breaking changes - all new parameters are optional. Your existing implementation will continue to work without modifications.
+
+#### Optional: Add New Features
+
+If you want to use the new features:
+
+```kotlin
+// Before (still works)
+Axeptio.initialize(
+    context = this,
+    clientId = "your-client-id",
+    cookiesVersion = "your-version"
+)
+
+// After (with new optional parameters)
+Axeptio.initialize(
+    context = this,
+    clientId = "your-client-id",
+    cookiesVersion = "your-version",
+    cookiesDurationDays = 365,  // Optional
+    widgetType = WidgetType.PRODUCTION,  // Optional
+    prId = null  // Optional
+)
+```
+
+---
+
+## Installation
+
+### Gradle (Kotlin DSL)
+
+Update your `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("io.axept.android:android-sdk:2.1.0")
+}
+```
+
+### GitHub Packages Authentication
+
+Ensure your `settings.gradle.kts` includes GitHub Maven credentials:
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/axeptio/axeptio-android-sdk")
+        credentials {
+            username = "YOUR_GITHUB_USERNAME"
+            password = "YOUR_GITHUB_TOKEN"
+        }
+    }
+}
+```
+
+---
+
+## Requirements
+
+- **Minimum SDK:** Android 8.0 (API level 26)
+- **Target SDK:** Android 14+ (API level 35)
+- **Kotlin:** 2.1.0+
+- **Java:** 8+
+
+---
+
+## Technical Details
+
+### Related Linear Issues
+- **MSK-119:** Configurable consent expiration
+- **MSK-79:** Widget type selection and PR testing support
+- **MSK-95:** TCF vendor consent parsing improvements
+- **MSK-101:** Storage scope for session-only consents
+
+### Full Changelog
+
+See [CHANGELOG.md](https://github.com/axeptio/axeptio-android-sdk-sources/blob/master/CHANGELOG.md) for detailed technical changes.
+
+---
+
+## Testing
+
+All features have been thoroughly tested:
+- ✅ 72/72 unit tests passing
+- ✅ Debug build tested
+- ✅ Release build tested
+- ✅ TCF compliance validated
+- ✅ Backward compatibility verified
+
+---
+
+## Support
+
+For issues, questions, or feature requests:
+- **GitHub Issues:** https://github.com/axeptio/axeptio-android-sdk-sources/issues
+- **Documentation:** https://github.com/axeptio/sample-app-android
+- **Source Code:** https://github.com/axeptio/axeptio-android-sdk-sources
+
+---
+
+## Acknowledgments
+
+This release includes contributions focused on improving developer experience and regulatory compliance.
+
+---
+
+**Previous Version:** 2.0.9
+**GitHub Release:** https://github.com/axeptio/axeptio-android-sdk-sources/releases/tag/2.1.0


### PR DESCRIPTION
## Merge Develop to Main

This PR merges the develop branch into main for the 2.1.0 release preparation.

### Changes Included

- **Release Notes**: Added comprehensive customer-facing documentation in `releases/2.1.0.md`
- **Previous Updates**: README updates and repository maintenance

### Purpose

Synchronize main branch with develop to prepare for the 2.1.0 release of the Android SDK.

---

Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges develop into main to ship Android SDK 2.1.0 and add customer-facing release notes. No code changes—this aligns branches for release.

- **Release Highlights**
  - Configurable consent expiration (cookiesDurationDays) — MSK-119
  - Widget testing modes (PRODUCTION/STAGING/PR) with optional prId — MSK-79
  - Session-only consent scope — MSK-101
  - Enhanced IAB TCF 2.2 handling; adds iabtcf decoder — MSK-95

<sup>Written for commit 5efefb30a972141a579b20d6d6b9e8223a5b7f50. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



